### PR TITLE
Add anonymous submit button via composer plugin patch

### DIFF
--- a/install/package.json
+++ b/install/package.json
@@ -14,7 +14,8 @@
         "lint": "npx tsc && eslint --cache ./nodebb .",
         "test": "npx tsc && nyc --reporter=html --reporter=text-summary mocha",
         "coverage": "nyc report --reporter=text-lcov > ./coverage/lcov.info",
-        "coveralls": "nyc report --reporter=text-lcov | coveralls && rm -r coverage"
+        "coveralls": "nyc report --reporter=text-lcov | coveralls && rm -r coverage",
+        "postinstall": "patch-package"
     },
     "nyc": {
         "exclude": [

--- a/install/package.json
+++ b/install/package.json
@@ -170,6 +170,7 @@
         "mocha-lcov-reporter": "1.3.0",
         "mockdate": "3.0.5",
         "nyc": "15.1.0",
+        "patch-package": "6.5.1",
         "smtp-server": "3.11.0",
         "typescript": "^4.9.4"
     },

--- a/patches/nodebb-plugin-composer-default+9.2.4.patch
+++ b/patches/nodebb-plugin-composer-default+9.2.4.patch
@@ -1,0 +1,104 @@
+diff --git a/node_modules/nodebb-plugin-composer-default/static/lib/composer.js b/node_modules/nodebb-plugin-composer-default/static/lib/composer.js
+index 46334e7..5d8b3ba 100644
+--- a/node_modules/nodebb-plugin-composer-default/static/lib/composer.js
++++ b/node_modules/nodebb-plugin-composer-default/static/lib/composer.js
+@@ -320,6 +320,7 @@ define('composer', [
+ 
+ 		var bodyEl = postContainer.find('textarea');
+ 		var submitBtn = postContainer.find('.composer-submit');
++		var submitAnonBtn = postContainer.find('.composer-submit-anon');
+ 
+ 		categoryList.init(postContainer, composer.posts[post_uuid]);
+ 		scheduler.init(postContainer, composer.posts);
+@@ -348,6 +349,14 @@ define('composer', [
+ 			post(post_uuid);
+ 		});
+ 
++		submitAnonBtn.on('click', function (e) {
++			e.preventDefault();
++			e.stopPropagation();	// Other click events bring composer back to active state which is undesired on submit
++
++			$(this).attr('disabled', true);
++			post(post_uuid, true);
++		});
++
+ 		require(['mousetrap'], function (mousetrap) {
+ 			mousetrap(postContainer.get(0)).bind('mod+enter', function () {
+ 				submitBtn.attr('disabled', true);
+@@ -622,7 +631,9 @@ define('composer', [
+ 		}, 20);
+ 	}
+ 
+-	async function post(post_uuid) {
++	async function post(post_uuid, isAnon) {
++		console.log("post method");
++		console.log({isAnon});
+ 		var postData = composer.posts[post_uuid];
+ 		var postContainer = $('.composer[data-uuid="' + post_uuid + '"]');
+ 		var handleEl = postContainer.find('.handle');
+@@ -631,6 +642,7 @@ define('composer', [
+ 		var thumbEl = postContainer.find('input#topic-thumb-url');
+ 		var onComposeRoute = postData.hasOwnProperty('template') && postData.template.compose === true;
+ 		const submitBtn = postContainer.find('.composer-submit');
++		const submitAnonBtn = postContainer.find('.composer-submit-anon');
+ 
+ 		titleEl.val(titleEl.val().trim());
+ 		bodyEl.val(utils.rtrim(bodyEl.val()));
+@@ -696,6 +708,7 @@ define('composer', [
+ 				cid: categoryList.getSelectedCid(),
+ 				tags: tags.getTags(post_uuid),
+ 				timestamp: scheduler.getTimestamp(),
++				isAnon,
+ 			};
+ 		} else if (action === 'posts.reply') {
+ 			route = `/topics/${postData.tid}`;
+@@ -705,6 +718,7 @@ define('composer', [
+ 				handle: handleEl ? handleEl.val() : undefined,
+ 				content: bodyEl.val(),
+ 				toPid: postData.toPid,
++				isAnon,
+ 			};
+ 		} else if (action === 'posts.edit') {
+ 			method = 'put';
+@@ -718,6 +732,7 @@ define('composer', [
+ 				thumb: thumbEl.val() || '',
+ 				tags: tags.getTags(post_uuid),
+ 				timestamp: scheduler.getTimestamp(),
++				isAnon,
+ 			};
+ 		}
+ 		var submitHookData = {
+@@ -741,6 +756,7 @@ define('composer', [
+ 		api[method](route, composerData)
+ 			.then((data) => {
+ 				submitBtn.removeAttr('disabled');
++				submitAnonBtn.removeAttr('disabled');
+ 				postData.submitted = true;
+ 
+ 				composer.discard(post_uuid);
+diff --git a/node_modules/nodebb-plugin-composer-default/static/templates/compose.tpl b/node_modules/nodebb-plugin-composer-default/static/templates/compose.tpl
+index 8ce50b9..88f550b 100644
+--- a/node_modules/nodebb-plugin-composer-default/static/templates/compose.tpl
++++ b/node_modules/nodebb-plugin-composer-default/static/templates/compose.tpl
+@@ -81,6 +81,8 @@
+ 					<a href="{discardRoute}" class="btn btn-default composer-discard" data-action="discard" tabindex="-1"><i class="fa fa-times"></i> [[topic:composer.discard]]</a>
+ 
+ 					<button type="submit" form="compose-form" class="btn btn-primary composer-submit" data-action="post" tabindex="6" data-text-variant=" [[topic:composer.schedule]]"><i class="fa fa-check"></i> [[topic:composer.submit]]</button>
++
++					<button type="submit" form="compose-form" class="btn btn-info composer-submit-anon" data-action="post" tabindex="6" data-text-variant=" [[topic:composer.schedule]] as Anonymous"><i class="fa fa-check"></i> [[topic:composer.submit]] as Anonymous</button>
+ 				</div>
+ 			</div>
+ 		</div>
+diff --git a/node_modules/nodebb-plugin-composer-default/static/templates/composer.tpl b/node_modules/nodebb-plugin-composer-default/static/templates/composer.tpl
+index cf9de24..ad95601 100644
+--- a/node_modules/nodebb-plugin-composer-default/static/templates/composer.tpl
++++ b/node_modules/nodebb-plugin-composer-default/static/templates/composer.tpl
+@@ -56,6 +56,8 @@
+ 
+ 				<ul class="dropdown-menu">{{{ each submitOptions }}}<li><a href="#" data-action="{./action}">{./text}</a></li>{{{ end }}}</ul>
+ 				<button class="btn btn-primary composer-submit" data-action="post" tabindex="6" data-text-variant=" [[topic:composer.schedule]]"><i class="fa fa-check"></i> [[topic:composer.submit]]</button>
++				<button class="btn btn-info composer-submit-anon" data-action="post" tabindex="6" data-text-variant=" [[topic:composer.schedule]] as Anonymous"><i class="fa fa-check"></i> [[topic:composer.submit]] as Anonymous</button>
++
+ 				<button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+ 					<span class="caret"></span>
+ 					<span class="sr-only">[[topic:composer.additional-options]]</span>

--- a/test/package-install.js
+++ b/test/package-install.js
@@ -72,16 +72,16 @@ describe('Package install lib', () => {
         });
 
         it('should deep merge nested objects', async () => {
-            current.scripts.postinstall = 'echo "I am a silly bean";';
+            current.scripts.testpostinstall = 'echo "I am a silly bean";';
             await fs.writeFile(packageFilePath, JSON.stringify(current, null, 4));
             source.scripts.preinstall = 'echo "What are you?";';
             await fs.writeFile(sourcePackagePath, JSON.stringify(source, null, 4));
-            source.scripts.postinstall = 'echo "I am a silly bean";';
+            source.scripts.testpostinstall = 'echo "I am a silly bean";';
 
             pkgInstall.updatePackageFile();
             const updated = JSON.parse(await fs.readFile(packageFilePath, 'utf8'));
             assert.deepStrictEqual(updated, source);
-            assert.strictEqual(updated.scripts.postinstall, 'echo "I am a silly bean";');
+            assert.strictEqual(updated.scripts.testpostinstall, 'echo "I am a silly bean";');
             assert.strictEqual(updated.scripts.preinstall, 'echo "What are you?";');
         });
 


### PR DESCRIPTION
Resolves #13 

Add anonymous submit button to the composer that adds `isAnon` field with value `true` to `POST` request body when pressed. 
The composer form is a NodeBB plugin that lives in the node_modules folder. Its code is in a different [repo](https://github.com/NodeBB/nodebb-plugin-composer-default). So, I am patching the module with `patch-package` to add the "Submit as Anonymous" button and `isAnon` as an argument to the `post` method.

As a next step, we should discuss whether forking the plugin and translating it to TypeScript is within the scope of our sprint. We would have to implement it as a custom composer plugin. 

- Passes linter locally when running `npm run lint`
- Passes all tests locally when running `npm run test`

![image](https://user-images.githubusercontent.com/98926767/218280438-278a3663-64f6-4ed5-8b40-3d605107adaf.png)

![image](https://user-images.githubusercontent.com/98926767/218280403-d2702de9-2bcf-4949-992a-ccdf55ec73b1.png)