### PR TITLE
Converted "src/controllers/categories.js" from JS to TS 

### DIFF
--- a/src/controllers/categories.js
+++ b/src/controllers/categories.js
@@ -130,6 +130,22 @@ async function list(req, res) {
     res.render('categories', data);
 }
 exports.list = list;
+/**
+ * The original JS file had its export like
+ * "module.exports.list = async function list(....."
+ * In TS, this is supposed to be like:
+ * "export async function list (..."
+ * But when I did that, ESLint complains and tells me to do
+ * "export default async function list (..."
+ * since it sees that list is the only function exported in this file.
+ * But little does ESLint know that if I do that, then the compiled JS
+ *  file would do the equivalent of:
+ * "module.exports.default = async function list(..."
+ * which might mess up other modules that are trying to include
+ * this file (and tests would fail).
+ * So this dummy function is included just so that ESLint won't complain
+ * about the export syntax.
+ */
 function dummy() {
     console.log('dummy function');
 }

--- a/src/controllers/categories.js
+++ b/src/controllers/categories.js
@@ -1,68 +1,136 @@
-'use strict';
-
-const nconf = require('nconf');
-const _ = require('lodash');
-
-const categories = require('../categories');
-const meta = require('../meta');
-const posts = require('../posts');
-const pagination = require('../pagination');
-const helpers = require('./helpers');
-const privileges = require('../privileges');
-
-const categoriesController = module.exports;
-
-categoriesController.list = async function (req, res) {
+"use strict";
+var __asyncValues = (this && this.__asyncValues) || function (o) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var m = o[Symbol.asyncIterator], i;
+    return m ? m.call(o) : (o = typeof __values === "function" ? __values(o) : o[Symbol.iterator](), i = {}, verb("next"), verb("throw"), verb("return"), i[Symbol.asyncIterator] = function () { return this; }, i);
+    function verb(n) { i[n] = o[n] && function (v) { return new Promise(function (resolve, reject) { v = o[n](v), settle(resolve, reject, v.done, v.value); }); }; }
+    function settle(resolve, reject, d, v) { Promise.resolve(v).then(function(v) { resolve({ value: v, done: d }); }, reject); }
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.dummy = exports.list = void 0;
+const nconf_1 = __importDefault(require("nconf"));
+const lodash_1 = __importDefault(require("lodash"));
+const categories_1 = __importDefault(require("../categories"));
+const meta_1 = __importDefault(require("../meta"));
+const posts_1 = __importDefault(require("../posts"));
+const pagination_1 = __importDefault(require("../pagination"));
+const helpers_1 = __importDefault(require("./helpers"));
+const privileges_1 = __importDefault(require("../privileges"));
+async function list(req, res) {
+    var _a, e_1, _b, _c, _d, e_2, _e, _f;
     res.locals.metaTags = [{
-        name: 'title',
-        content: String(meta.config.title || 'NodeBB'),
-    }, {
-        property: 'og:type',
-        content: 'website',
-    }];
-
-    const allRootCids = await categories.getAllCidsFromSet('cid:0:children');
-    const rootCids = await privileges.categories.filterCids('find', allRootCids, req.uid);
-    const pageCount = Math.max(1, Math.ceil(rootCids.length / meta.config.categoriesPerPage));
+            name: 'title',
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            content: String(meta_1.default.config.title || 'NodeBB'),
+        }, {
+            property: 'og:type',
+            content: 'website',
+        }];
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const categoriesPerPage = meta_1.default.config.categoriesPerPage;
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const allRootCids = await categories_1.default.getAllCidsFromSet('cid:0:children');
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const rootCids = await privileges_1.default.categories.filterCids('find', allRootCids, req.uid);
+    const pageCount = Math.max(1, Math.ceil(rootCids.length / categoriesPerPage));
     const page = Math.min(parseInt(req.query.page, 10) || 1, pageCount);
-    const start = Math.max(0, (page - 1) * meta.config.categoriesPerPage);
-    const stop = start + meta.config.categoriesPerPage - 1;
+    const start = Math.max(0, (page - 1) * categoriesPerPage);
+    const stop = start + categoriesPerPage - 1;
     const pageCids = rootCids.slice(start, stop + 1);
-
-    const allChildCids = _.flatten(await Promise.all(pageCids.map(categories.getChildrenCids)));
-    const childCids = await privileges.categories.filterCids('find', allChildCids, req.uid);
-    const categoryData = await categories.getCategories(pageCids.concat(childCids), req.uid);
-    const tree = categories.getTree(categoryData, 0);
-    await categories.getRecentTopicReplies(categoryData, req.uid, req.query);
-
+    const allChildCids = lodash_1.default.flatten(await Promise.all(pageCids.map(categories_1.default.getChildrenCids)));
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const childCids = await privileges_1.default.categories.filterCids('find', allChildCids, req.uid);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const categoryData = await categories_1.default.getCategories(pageCids.concat(childCids), req.uid);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const tree = categories_1.default.getTree(categoryData, 0);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await categories_1.default.getRecentTopicReplies(categoryData, req.uid, req.query);
     const data = {
-        title: meta.config.homePageTitle || '[[pages:home]]',
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        title: meta_1.default.config.homePageTitle || '[[pages:home]]',
         selectCategoryLabel: '[[pages:categories]]',
         categories: tree,
-        pagination: pagination.create(page, pageCount, req.query),
+        pagination: pagination_1.default.create(page, pageCount, req.query),
+        breadcrumbs: undefined,
     };
-
     data.categories.forEach((category) => {
         if (category) {
-            helpers.trimChildren(category);
-            helpers.setCategoryTeaser(category);
+            helpers_1.default.trimChildren(category);
+            helpers_1.default.setCategoryTeaser(category);
         }
     });
-
-    if (req.originalUrl.startsWith(`${nconf.get('relative_path')}/api/categories`) || req.originalUrl.startsWith(`${nconf.get('relative_path')}/categories`)) {
+    if (req.originalUrl.startsWith(`${nconf_1.default.get('relative_path')}/api/categories`) || req.originalUrl.startsWith(`${nconf_1.default.get('relative_path')}/categories`)) {
         data.title = '[[pages:categories]]';
-        data.breadcrumbs = helpers.buildBreadcrumbs([{ text: data.title }]);
+        data.breadcrumbs = helpers_1.default.buildBreadcrumbs([{ text: data.title }]);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         res.locals.metaTags.push({
             property: 'og:title',
             content: '[[pages:categories]]',
         });
     }
-
-    for await (const c of data.categories) {
-        for await (const p of c.posts) {
-            p.isAnon = await posts.getPostField(p.pid, 'isAnon');
+    try {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        for (var _g = true, _h = __asyncValues(data.categories), _j; _j = await _h.next(), _a = _j.done, !_a;) {
+            _c = _j.value;
+            _g = false;
+            try {
+                const c = _c;
+                try {
+                    // The next line calls a function in a module that has not been updated to TS yet
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                    for (var _k = true, _l = (e_2 = void 0, __asyncValues(c.posts)), _m; _m = await _l.next(), _d = _m.done, !_d;) {
+                        _f = _m.value;
+                        _k = false;
+                        try {
+                            const p = _f;
+                            // The next line calls a function in a module that has not been updated to TS yet
+                            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                            p.isAnon = await posts_1.default.getPostField(p.pid, 'isAnon');
+                        }
+                        finally {
+                            _k = true;
+                        }
+                    }
+                }
+                catch (e_2_1) { e_2 = { error: e_2_1 }; }
+                finally {
+                    try {
+                        if (!_k && !_d && (_e = _l.return)) await _e.call(_l);
+                    }
+                    finally { if (e_2) throw e_2.error; }
+                }
+            }
+            finally {
+                _g = true;
+            }
         }
     }
-
+    catch (e_1_1) { e_1 = { error: e_1_1 }; }
+    finally {
+        try {
+            if (!_g && !_a && (_b = _h.return)) await _b.call(_h);
+        }
+        finally { if (e_1) throw e_1.error; }
+    }
     res.render('categories', data);
-};
+}
+exports.list = list;
+function dummy() {
+    console.log('dummy function');
+}
+exports.dummy = dummy;

--- a/src/controllers/categories.js
+++ b/src/controllers/categories.js
@@ -10,7 +10,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.dummy = exports.list = void 0;
+exports.list = void 0;
 const nconf_1 = __importDefault(require("nconf"));
 const lodash_1 = __importDefault(require("lodash"));
 const categories_1 = __importDefault(require("../categories"));
@@ -19,6 +19,24 @@ const posts_1 = __importDefault(require("../posts"));
 const pagination_1 = __importDefault(require("../pagination"));
 const helpers_1 = __importDefault(require("./helpers"));
 const privileges_1 = __importDefault(require("../privileges"));
+/**
+ * The original JS file had its export like
+ * "module.exports.list = async function list(....."
+ * In TS, this is supposed to be like:
+ * "export async function list (..."
+ * But when I did that, ESLint complains and tells me to do
+ * "export default async function list (..."
+ * since it sees that list is the only function exported in this file.
+ * But little does ESLint know that if I do that, then the compiled JS
+ *  file would do the equivalent of:
+ * "module.exports.default = async function list(..."
+ * which might mess up other modules that are trying to include
+ * this file (and tests would fail).
+ * So this dummy function is included just so that ESLint won't complain
+ * about the export syntax.
+ */
+// The next line calls a function in a module that has not been updated to TS yet
+// eslint-disable-next-line import/prefer-default-export
 async function list(req, res) {
     var _a, e_1, _b, _c, _d, e_2, _e, _f;
     res.locals.metaTags = [{
@@ -130,23 +148,3 @@ async function list(req, res) {
     res.render('categories', data);
 }
 exports.list = list;
-/**
- * The original JS file had its export like
- * "module.exports.list = async function list(....."
- * In TS, this is supposed to be like:
- * "export async function list (..."
- * But when I did that, ESLint complains and tells me to do
- * "export default async function list (..."
- * since it sees that list is the only function exported in this file.
- * But little does ESLint know that if I do that, then the compiled JS
- *  file would do the equivalent of:
- * "module.exports.default = async function list(..."
- * which might mess up other modules that are trying to include
- * this file (and tests would fail).
- * So this dummy function is included just so that ESLint won't complain
- * about the export syntax.
- */
-function dummy() {
-    console.log('dummy function');
-}
-exports.dummy = dummy;

--- a/src/controllers/categories.ts
+++ b/src/controllers/categories.ts
@@ -1,0 +1,102 @@
+import nconf from 'nconf';
+import _ from 'lodash';
+import { Request, Response } from 'express';
+import categories from '../categories';
+import meta from '../meta';
+import posts from '../posts';
+import pagination from '../pagination';
+import helpers from './helpers';
+import privileges from '../privileges';
+import { CategoryObject } from '../types';
+
+interface ExtendedRequest extends Request {
+    uid: number;
+}
+
+export async function list(req: ExtendedRequest, res: Response) {
+    res.locals.metaTags = [{
+        name: 'title',
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        content: String(meta.config.title || 'NodeBB'),
+    }, {
+        property: 'og:type',
+        content: 'website',
+    }];
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const categoriesPerPage = meta.config.categoriesPerPage as number;
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const allRootCids = await categories.getAllCidsFromSet('cid:0:children') as number[];
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const rootCids = await privileges.categories.filterCids('find', allRootCids, req.uid) as number[];
+    const pageCount = Math.max(1, Math.ceil(rootCids.length / categoriesPerPage));
+    const page = Math.min(parseInt(req.query.page as string, 10) || 1, pageCount);
+    const start = Math.max(0, (page - 1) * categoriesPerPage);
+
+    const stop = start + categoriesPerPage - 1;
+    const pageCids = rootCids.slice(start, stop + 1);
+
+    const allChildCids = _.flatten(await Promise.all(pageCids.map(categories.getChildrenCids)));
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const childCids = await privileges.categories.filterCids('find', allChildCids, req.uid) as number[];
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const categoryData = await
+    categories.getCategories(pageCids.concat(childCids), req.uid) as (CategoryObject[] | null);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const tree = categories.getTree(categoryData, 0);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await categories.getRecentTopicReplies(categoryData, req.uid, req.query);
+
+    const data = {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        title: (meta.config.homePageTitle as string) || '[[pages:home]]',
+        selectCategoryLabel: '[[pages:categories]]',
+        categories: tree,
+        pagination: pagination.create(page, pageCount, req.query),
+        breadcrumbs: undefined,
+    };
+
+    data.categories.forEach((category) => {
+        if (category) {
+            helpers.trimChildren(category);
+            helpers.setCategoryTeaser(category);
+        }
+    });
+
+    if (req.originalUrl.startsWith(`${nconf.get('relative_path') as string}/api/categories`) || req.originalUrl.startsWith(`${nconf.get('relative_path') as string}/categories`)) {
+        data.title = '[[pages:categories]]';
+        data.breadcrumbs = helpers.buildBreadcrumbs([{ text: data.title }]);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        res.locals.metaTags.push({
+            property: 'og:title',
+            content: '[[pages:categories]]',
+        });
+    }
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    for await (const c of data.categories) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        for await (const p of c.posts) {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            p.isAnon = await posts.getPostField(p.pid, 'isAnon') as boolean;
+        }
+    }
+
+    res.render('categories', data);
+}
+
+export function dummy() {
+    console.log('dummy function');
+}

--- a/src/controllers/categories.ts
+++ b/src/controllers/categories.ts
@@ -13,6 +13,24 @@ interface ExtendedRequest extends Request {
     uid: number;
 }
 
+/**
+ * The original JS file had its export like
+ * "module.exports.list = async function list(....."
+ * In TS, this is supposed to be like:
+ * "export async function list (..."
+ * But when I did that, ESLint complains and tells me to do
+ * "export default async function list (..."
+ * since it sees that list is the only function exported in this file.
+ * But little does ESLint know that if I do that, then the compiled JS
+ *  file would do the equivalent of:
+ * "module.exports.default = async function list(..."
+ * which might mess up other modules that are trying to include
+ * this file (and tests would fail).
+ * So this dummy function is included just so that ESLint won't complain
+ * about the export syntax.
+ */
+// The next line calls a function in a module that has not been updated to TS yet
+// eslint-disable-next-line import/prefer-default-export
 export async function list(req: ExtendedRequest, res: Response) {
     res.locals.metaTags = [{
         name: 'title',
@@ -95,24 +113,4 @@ export async function list(req: ExtendedRequest, res: Response) {
     }
 
     res.render('categories', data);
-}
-
-/**
- * The original JS file had its export like
- * "module.exports.list = async function list(....."
- * In TS, this is supposed to be like:
- * "export async function list (..."
- * But when I did that, ESLint complains and tells me to do
- * "export default async function list (..."
- * since it sees that list is the only function exported in this file.
- * But little does ESLint know that if I do that, then the compiled JS
- *  file would do the equivalent of:
- * "module.exports.default = async function list(..."
- * which might mess up other modules that are trying to include
- * this file (and tests would fail).
- * So this dummy function is included just so that ESLint won't complain
- * about the export syntax.
- */
-export function dummy() {
-    console.log('dummy function');
 }

--- a/src/controllers/categories.ts
+++ b/src/controllers/categories.ts
@@ -97,6 +97,22 @@ export async function list(req: ExtendedRequest, res: Response) {
     res.render('categories', data);
 }
 
+/**
+ * The original JS file had its export like
+ * "module.exports.list = async function list(....."
+ * In TS, this is supposed to be like:
+ * "export async function list (..."
+ * But when I did that, ESLint complains and tells me to do
+ * "export default async function list (..."
+ * since it sees that list is the only function exported in this file.
+ * But little does ESLint know that if I do that, then the compiled JS
+ *  file would do the equivalent of:
+ * "module.exports.default = async function list(..."
+ * which might mess up other modules that are trying to include
+ * this file (and tests would fail).
+ * So this dummy function is included just so that ESLint won't complain
+ * about the export syntax.
+ */
 export function dummy() {
     console.log('dummy function');
 }

--- a/src/controllers/composer.js
+++ b/src/controllers/composer.js
@@ -1,15 +1,6 @@
 "use strict";
 // This is one of the two example TypeScript files included with the NodeBB repository
 // It is meant to serve as an example to assist you with your HW1 translation
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -21,92 +12,86 @@ const plugins_1 = __importDefault(require("../plugins"));
 const topics_1 = __importDefault(require("../topics"));
 const posts_1 = __importDefault(require("../posts"));
 const helpers_1 = __importDefault(require("./helpers"));
-function get(req, res, callback) {
-    return __awaiter(this, void 0, void 0, function* () {
-        res.locals.metaTags = Object.assign(Object.assign({}, res.locals.metaTags), { name: 'robots', content: 'noindex' });
-        const data = yield plugins_1.default.hooks.fire('filter:composer.build', {
-            req: req,
-            res: res,
-            next: callback,
-            templateData: {},
-        });
-        if (res.headersSent) {
-            return;
-        }
-        if (!data || !data.templateData) {
-            return callback(new Error('[[error:invalid-data]]'));
-        }
-        if (data.templateData.disabled) {
-            res.render('', {
-                title: '[[modules:composer.compose]]',
-            });
-        }
-        else {
-            data.templateData.title = '[[modules:composer.compose]]';
-            res.render('compose', data.templateData);
-        }
+async function get(req, res, callback) {
+    res.locals.metaTags = Object.assign(Object.assign({}, res.locals.metaTags), { name: 'robots', content: 'noindex' });
+    const data = await plugins_1.default.hooks.fire('filter:composer.build', {
+        req: req,
+        res: res,
+        next: callback,
+        templateData: {},
     });
+    if (res.headersSent) {
+        return;
+    }
+    if (!data || !data.templateData) {
+        return callback(new Error('[[error:invalid-data]]'));
+    }
+    if (data.templateData.disabled) {
+        res.render('', {
+            title: '[[modules:composer.compose]]',
+        });
+    }
+    else {
+        data.templateData.title = '[[modules:composer.compose]]';
+        res.render('compose', data.templateData);
+    }
 }
 exports.get = get;
-function post(req, res) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const { body } = req;
-        const data = {
-            uid: req.uid,
-            req: req,
-            timestamp: Date.now(),
-            content: body.content,
-            fromQueue: false,
-        };
-        req.body.noscript = 'true';
-        if (!data.content) {
-            return yield helpers_1.default.noScriptErrors(req, res, '[[error:invalid-data]]', 400);
-        }
-        function queueOrPost(postFn, data) {
-            return __awaiter(this, void 0, void 0, function* () {
-                // The next line calls a function in a module that has not been updated to TS yet
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                const shouldQueue = yield posts_1.default.shouldQueue(req.uid, data);
-                if (shouldQueue) {
-                    delete data.req;
-                    // The next line calls a function in a module that has not been updated to TS yet
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                    return yield posts_1.default.addToQueue(data);
-                }
-                return yield postFn(data);
-            });
-        }
-        try {
-            let result;
-            if (body.tid) {
-                data.tid = body.tid;
-                result = yield queueOrPost(topics_1.default.reply, data);
-            }
-            else if (body.cid) {
-                data.cid = body.cid;
-                data.title = body.title;
-                data.tags = [];
-                data.thumb = '';
-                result = yield queueOrPost(topics_1.default.post, data);
-            }
-            else {
-                throw new Error('[[error:invalid-data]]');
-            }
-            if (result.queued) {
-                return res.redirect(`${nconf_1.default.get('relative_path') || '/'}?noScriptMessage=[[success:post-queued]]`);
-            }
-            const uid = result.uid ? result.uid : result.topicData.uid;
+async function post(req, res) {
+    const { body } = req;
+    const data = {
+        uid: req.uid,
+        req: req,
+        timestamp: Date.now(),
+        content: body.content,
+        fromQueue: false,
+    };
+    req.body.noscript = 'true';
+    if (!data.content) {
+        return await helpers_1.default.noScriptErrors(req, res, '[[error:invalid-data]]', 400);
+    }
+    async function queueOrPost(postFn, data) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const shouldQueue = await posts_1.default.shouldQueue(req.uid, data);
+        if (shouldQueue) {
+            delete data.req;
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            user_1.default.updateOnlineUsers(uid);
-            const path = result.pid ? `/post/${result.pid}` : `/topic/${result.topicData.slug}`;
-            res.redirect(nconf_1.default.get('relative_path') + path);
+            return await posts_1.default.addToQueue(data);
         }
-        catch (err) {
-            if (err instanceof Error) {
-                yield helpers_1.default.noScriptErrors(req, res, err.message, 400);
-            }
+        return await postFn(data);
+    }
+    try {
+        let result;
+        if (body.tid) {
+            data.tid = body.tid;
+            result = await queueOrPost(topics_1.default.reply, data);
         }
-    });
+        else if (body.cid) {
+            data.cid = body.cid;
+            data.title = body.title;
+            data.tags = [];
+            data.thumb = '';
+            result = await queueOrPost(topics_1.default.post, data);
+        }
+        else {
+            throw new Error('[[error:invalid-data]]');
+        }
+        if (result.queued) {
+            return res.redirect(`${nconf_1.default.get('relative_path') || '/'}?noScriptMessage=[[success:post-queued]]`);
+        }
+        const uid = result.uid ? result.uid : result.topicData.uid;
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        user_1.default.updateOnlineUsers(uid);
+        const path = result.pid ? `/post/${result.pid}` : `/topic/${result.topicData.slug}`;
+        res.redirect(nconf_1.default.get('relative_path') + path);
+    }
+    catch (err) {
+        if (err instanceof Error) {
+            await helpers_1.default.noScriptErrors(req, res, err.message, 400);
+        }
+    }
 }
 exports.post = post;

--- a/src/social.js
+++ b/src/social.js
@@ -1,15 +1,6 @@
 "use strict";
 // This is one of the two example TypeScript files included with the NodeBB repository
 // It is meant to serve as an example to assist you with your HW1 translation
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -19,56 +10,50 @@ const lodash_1 = __importDefault(require("lodash"));
 const plugins_1 = __importDefault(require("./plugins"));
 const database_1 = __importDefault(require("./database"));
 let postSharing = null;
-function getPostSharing() {
-    return __awaiter(this, void 0, void 0, function* () {
-        if (postSharing) {
-            return lodash_1.default.cloneDeep(postSharing);
-        }
-        let networks = [
-            {
-                id: 'facebook',
-                name: 'Facebook',
-                class: 'fa-facebook',
-                activated: null,
-            },
-            {
-                id: 'twitter',
-                name: 'Twitter',
-                class: 'fa-twitter',
-                activated: null,
-            },
-        ];
-        networks = (yield plugins_1.default.hooks.fire('filter:social.posts', networks));
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        const activated = yield database_1.default.getSetMembers('social:posts.activated');
-        networks.forEach((network) => {
-            network.activated = activated.includes(network.id);
-        });
-        postSharing = networks;
-        return lodash_1.default.cloneDeep(networks);
+async function getPostSharing() {
+    if (postSharing) {
+        return lodash_1.default.cloneDeep(postSharing);
+    }
+    let networks = [
+        {
+            id: 'facebook',
+            name: 'Facebook',
+            class: 'fa-facebook',
+            activated: null,
+        },
+        {
+            id: 'twitter',
+            name: 'Twitter',
+            class: 'fa-twitter',
+            activated: null,
+        },
+    ];
+    networks = await plugins_1.default.hooks.fire('filter:social.posts', networks);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const activated = await database_1.default.getSetMembers('social:posts.activated');
+    networks.forEach((network) => {
+        network.activated = activated.includes(network.id);
     });
+    postSharing = networks;
+    return lodash_1.default.cloneDeep(networks);
 }
 exports.getPostSharing = getPostSharing;
-function getActivePostSharing() {
-    return __awaiter(this, void 0, void 0, function* () {
-        const networks = yield getPostSharing();
-        return networks.filter(network => network && network.activated);
-    });
+async function getActivePostSharing() {
+    const networks = await getPostSharing();
+    return networks.filter(network => network && network.activated);
 }
 exports.getActivePostSharing = getActivePostSharing;
-function setActivePostSharingNetworks(networkIDs) {
-    return __awaiter(this, void 0, void 0, function* () {
-        postSharing = null;
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        yield database_1.default.delete('social:posts.activated');
-        if (!networkIDs.length) {
-            return;
-        }
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        yield database_1.default.setAdd('social:posts.activated', networkIDs);
-    });
+async function setActivePostSharingNetworks(networkIDs) {
+    postSharing = null;
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await database_1.default.delete('social:posts.activated');
+    if (!networkIDs.length) {
+        return;
+    }
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await database_1.default.setAdd('social:posts.activated', networkIDs);
 }
 exports.setActivePostSharingNetworks = setActivePostSharingNetworks;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "allowJs": false,
-    "target": "es6",
+    "target": "ES2017",
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,


### PR DESCRIPTION
resolves #16 

Converted `src/controllers/categories.js` from JS to TS
- Added `src/controllers/categories.ts`
- Generated `src/controllers/categories.js` using `npx tsc`
- Added type annotations in compliance with the linter
- Still passes all tests when testing locally 
- Silenced `@typescript-eslint/no-unsafe-member-access` and `@typescript-eslint/no-unsafe-call errors` when calling a function on untranslated modules
- Change 'es6' to 'ES2017' to avoid timeouts on tests
