### PR TITLE
Converted "src/posts/create.js" from JS to TS

### DIFF
--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -1,16 +1,17 @@
-'use strict';
-
-const _ = require('lodash');
-
-const meta = require('../meta');
-const db = require('../database');
-const plugins = require('../plugins');
-const user = require('../user');
-const topics = require('../topics');
-const categories = require('../categories');
-const groups = require('../groups');
-const utils = require('../utils');
-
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const lodash_1 = __importDefault(require("lodash"));
+const meta_1 = __importDefault(require("../meta"));
+const database_1 = __importDefault(require("../database"));
+const plugins_1 = __importDefault(require("../plugins"));
+const user_1 = __importDefault(require("../user"));
+const topics_1 = __importDefault(require("../topics"));
+const categories_1 = __importDefault(require("../categories"));
+const groups_1 = __importDefault(require("../groups"));
+const utils_1 = __importDefault(require("../utils"));
 module.exports = function (Posts) {
     Posts.create = async function (data) {
         // This is an internal method, consider using Topics.reply instead
@@ -20,16 +21,13 @@ module.exports = function (Posts) {
         const content = data.content.toString();
         const timestamp = data.timestamp || Date.now();
         const isMain = data.isMain || false;
-
         if (!uid && parseInt(uid, 10) !== 0) {
             throw new Error('[[error:invalid-uid]]');
         }
-
-        if (data.toPid && !utils.isNumber(data.toPid)) {
+        if (data.toPid && !utils_1.default.isNumber(data.toPid)) {
             throw new Error('[[error:invalid-pid]]');
         }
-
-        const pid = await db.incrObjectField('global', 'nextPid');
+        const pid = await database_1.default.incrObjectField('global', 'nextPid');
         let postData = {
             pid: pid,
             uid: uid,
@@ -38,48 +36,42 @@ module.exports = function (Posts) {
             timestamp: timestamp,
             isAnon: isAnon,
         };
-
         if (data.toPid) {
             postData.toPid = data.toPid;
         }
-        if (data.ip && meta.config.trackIpPerPost) {
+        if (data.ip && meta_1.default.config.trackIpPerPost) {
             postData.ip = data.ip;
         }
         if (data.handle && !parseInt(uid, 10)) {
             postData.handle = data.handle;
         }
-
-        let result = await plugins.hooks.fire('filter:post.create', { post: postData, data: data });
+        let result = await plugins_1.default.hooks.fire('filter:post.create', { post: postData, data: data });
         postData = result.post;
-        await db.setObject(`post:${postData.pid}`, postData);
-
-        const topicData = await topics.getTopicFields(tid, ['cid', 'pinned']);
+        await database_1.default.setObject(`post:${postData.pid}`, postData);
+        const topicData = await topics_1.default.getTopicFields(tid, ['cid', 'pinned']);
         postData.cid = topicData.cid;
-
         await Promise.all([
-            db.sortedSetAdd('posts:pid', timestamp, postData.pid),
-            db.incrObjectField('global', 'postCount'),
-            user.onNewPostMade(postData),
-            topics.onNewPostMade(postData),
-            categories.onNewPostMade(topicData.cid, topicData.pinned, postData),
-            groups.onNewPostMade(postData),
+            database_1.default.sortedSetAdd('posts:pid', timestamp, postData.pid),
+            database_1.default.incrObjectField('global', 'postCount'),
+            user_1.default.onNewPostMade(postData),
+            topics_1.default.onNewPostMade(postData),
+            categories_1.default.onNewPostMade(topicData.cid, topicData.pinned, postData),
+            groups_1.default.onNewPostMade(postData),
             addReplyTo(postData, timestamp),
             Posts.uploads.sync(postData.pid),
         ]);
-
-        result = await plugins.hooks.fire('filter:post.get', { post: postData, uid: data.uid });
+        result = await plugins_1.default.hooks.fire('filter:post.get', { post: postData, uid: data.uid });
         result.post.isMain = isMain;
-        plugins.hooks.fire('action:post.save', { post: _.clone(result.post) });
+        plugins_1.default.hooks.fire('action:post.save', { post: lodash_1.default.clone(result.post) });
         return result.post;
     };
-
     async function addReplyTo(postData, timestamp) {
         if (!postData.toPid) {
             return;
         }
         await Promise.all([
-            db.sortedSetAdd(`pid:${postData.toPid}:replies`, timestamp, postData.pid),
-            db.incrObjectField(`post:${postData.toPid}`, 'replies'),
+            database_1.default.sortedSetAdd(`pid:${postData.toPid}:replies`, timestamp, postData.pid),
+            database_1.default.incrObjectField(`post:${postData.toPid}`, 'replies'),
         ]);
     }
 };

--- a/src/posts/create.ts
+++ b/src/posts/create.ts
@@ -1,0 +1,84 @@
+import _ from 'lodash';
+
+import meta from '../meta';
+import db from '../database';
+import plugins from '../plugins';
+import user from '../user';
+import topics from '../topics';
+import categories from '../categories';
+import groups from '../groups';
+import { PostObjectPartial } from '../types';
+import utils from '../utils';
+
+module.exports = function (Posts) {
+    Posts.create = async function (data) {
+        // This is an internal method, consider using Topics.reply instead
+        const { uid } = data;
+        const { tid } = data;
+        const { isAnon } = data;
+        const content = data.content.toString();
+        const timestamp = data.timestamp || Date.now();
+        const isMain = data.isMain || false;
+
+        if (!uid && parseInt(uid, 10) !== 0) {
+            throw new Error('[[error:invalid-uid]]');
+        }
+
+        if (data.toPid && !utils.isNumber(data.toPid)) {
+            throw new Error('[[error:invalid-pid]]');
+        }
+
+        const pid = await db.incrObjectField('global', 'nextPid');
+        let postData: PostObjectPartial = {
+            pid: pid,
+            uid: uid,
+            tid: tid,
+            content: content,
+            timestamp: timestamp,
+            isAnon: isAnon,
+        };
+
+        if (data.toPid) {
+            postData.toPid = data.toPid;
+        }
+        if (data.ip && meta.config.trackIpPerPost) {
+            postData.ip = data.ip;
+        }
+        if (data.handle && !parseInt(uid, 10)) {
+            postData.handle = data.handle;
+        }
+
+        let result = await plugins.hooks.fire('filter:post.create', { post: postData, data: data });
+        postData = result.post;
+        await db.setObject(`post:${postData.pid}`, postData);
+
+        const topicData = await topics.getTopicFields(tid, ['cid', 'pinned']);
+        postData.cid = topicData.cid;
+
+        await Promise.all([
+            db.sortedSetAdd('posts:pid', timestamp, postData.pid),
+            db.incrObjectField('global', 'postCount'),
+            user.onNewPostMade(postData),
+            topics.onNewPostMade(postData),
+            categories.onNewPostMade(topicData.cid, topicData.pinned, postData),
+            groups.onNewPostMade(postData),
+            addReplyTo(postData, timestamp),
+            Posts.uploads.sync(postData.pid),
+        ]);
+
+        result = await plugins.hooks.fire('filter:post.get', { post: postData, uid: data.uid });
+        result.post.isMain = isMain;
+        plugins.hooks.fire('action:post.save', { post: _.clone(result.post) });
+        return result.post;
+    };
+
+    async function addReplyTo(postData, timestamp) {
+        if (!postData.toPid) {
+            return;
+        }
+        await Promise.all([
+            db.sortedSetAdd(`pid:${postData.toPid}:replies`, timestamp, postData.pid),
+            db.incrObjectField(`post:${postData.toPid}`, 'replies'),
+        ]);
+    }
+};

--- a/src/posts/create.ts
+++ b/src/posts/create.ts
@@ -7,10 +7,24 @@ import user from '../user';
 import topics from '../topics';
 import categories from '../categories';
 import groups from '../groups';
-import { PostObjectPartial } from '../types';
+import { PostObjectPartial, PostsMethods, PostWrapper, TopicObject } from '../types';
 import utils from '../utils';
 
-module.exports = function (Posts) {
+async function addReplyTo(postData: PostObjectPartial, timestamp: number) {
+    if (!postData.toPid) {
+        return;
+    }
+    await Promise.all([
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        db.sortedSetAdd(`pid:${postData.toPid}:replies`, timestamp, postData.pid),
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        db.incrObjectField(`post:${postData.toPid}`, 'replies'),
+    ]);
+}
+
+export = function (Posts: PostsMethods) {
     Posts.create = async function (data) {
         // This is an internal method, consider using Topics.reply instead
         const { uid } = data;
@@ -20,7 +34,7 @@ module.exports = function (Posts) {
         const timestamp = data.timestamp || Date.now();
         const isMain = data.isMain || false;
 
-        if (!uid && parseInt(uid, 10) !== 0) {
+        if (!uid && parseInt(uid as string, 10) !== 0) {
             throw new Error('[[error:invalid-uid]]');
         }
 
@@ -28,7 +42,9 @@ module.exports = function (Posts) {
             throw new Error('[[error:invalid-pid]]');
         }
 
-        const pid = await db.incrObjectField('global', 'nextPid');
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const pid = await db.incrObjectField('global', 'nextPid') as number;
         let postData: PostObjectPartial = {
             pid: pid,
             uid: uid,
@@ -41,44 +57,54 @@ module.exports = function (Posts) {
         if (data.toPid) {
             postData.toPid = data.toPid;
         }
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         if (data.ip && meta.config.trackIpPerPost) {
             postData.ip = data.ip;
         }
-        if (data.handle && !parseInt(uid, 10)) {
+        if (data.handle && !parseInt(uid as string, 10)) {
             postData.handle = data.handle;
         }
 
-        let result = await plugins.hooks.fire('filter:post.create', { post: postData, data: data });
+        let result = await plugins.hooks.fire('filter:post.create', { post: postData, data: data }) as PostWrapper;
         postData = result.post;
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         await db.setObject(`post:${postData.pid}`, postData);
 
-        const topicData = await topics.getTopicFields(tid, ['cid', 'pinned']);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const topicData = await topics.getTopicFields(tid, ['cid', 'pinned']) as TopicObject;
         postData.cid = topicData.cid;
 
         await Promise.all([
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             db.sortedSetAdd('posts:pid', timestamp, postData.pid),
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             db.incrObjectField('global', 'postCount'),
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             user.onNewPostMade(postData),
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             topics.onNewPostMade(postData),
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             categories.onNewPostMade(topicData.cid, topicData.pinned, postData),
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             groups.onNewPostMade(postData),
             addReplyTo(postData, timestamp),
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             Posts.uploads.sync(postData.pid),
         ]);
 
-        result = await plugins.hooks.fire('filter:post.get', { post: postData, uid: data.uid });
+        result = await plugins.hooks.fire('filter:post.get', { post: postData, uid: data.uid }) as PostWrapper;
         result.post.isMain = isMain;
-        plugins.hooks.fire('action:post.save', { post: _.clone(result.post) });
+        plugins.hooks.fire('action:post.save', { post: _.clone(result.post) }) as PostWrapper;
         return result.post;
     };
-
-    async function addReplyTo(postData, timestamp) {
-        if (!postData.toPid) {
-            return;
-        }
-        await Promise.all([
-            db.sortedSetAdd(`pid:${postData.toPid}:replies`, timestamp, postData.pid),
-            db.incrObjectField(`post:${postData.toPid}`, 'replies'),
-        ]);
-    }
 };

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -44,6 +44,9 @@ export type PostObjectPartial = {
   edited?: boolean | number;
   editedISO?: string;
   isAnon?: boolean | string;
+  toPid?: unknown;
+  ip?: number | string;
+  cid?: number;
 }
 
 export type PostField = number | string | boolean | TopicObject | CategoryObject | UserObjectSlim | null;

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -22,13 +22,14 @@ export type PostObject = {
   edited?: boolean | number;
   editedISO?: string;
   isAnon?: boolean | string;
+  isMain?: boolean;
 };
 
 export type PostObjectPartial = {
   pid?: number;
   tid?: number;
   content?: string;
-  uid?: number;
+  uid?: number | string;
   timestamp?: number;
   deleted?: boolean | number;
   upvotes?: number;
@@ -44,9 +45,10 @@ export type PostObjectPartial = {
   edited?: boolean | number;
   editedISO?: string;
   isAnon?: boolean | string;
-  toPid?: unknown;
+  toPid?: number | string;
   ip?: number | string;
   cid?: number;
+  isMain?: boolean;
 }
 
 export type PostField = number | string | boolean | TopicObject | CategoryObject | UserObjectSlim | null;
@@ -54,6 +56,10 @@ export type PostField = number | string | boolean | TopicObject | CategoryObject
 export type OptionalPost = PostObject | null;
 
 export type OptionalPostList = OptionalPost[] | null;
+
+export interface PostWrapper {
+  post: OptionalPost;
+}
 
 export interface PostsWrapper {
     posts?: OptionalPostList;
@@ -81,5 +87,8 @@ export interface PostsMethods {
     getPostSummaryByPids: (pids: number[], uid: number, options: PostSummaryOptions) => Promise<OptionalPostList>;
     parsePost: (post: OptionalPost) => Promise<OptionalPost>;
     overrideGuestHandle: (post: PostObject, handle: string) => void;
+
+    create: (data: PostObjectPartial) => Promise<PostObject>;
+    uploads: any;
 }
 


### PR DESCRIPTION
Resolves #20 

Converted `src/posts/create.js` from JS to TS
- Added `src/posts/create.ts`
- Generated `src/posts/create.js` using `npx tsc`
- Added type annotations in compliance with the linter
- Still passes all tests when testing locally
- Silenced @typescript-eslint/no-unsafe-member-access and @typescript-eslint/no-unsafe-call errors when calling a function on untranslated modules