### PR TITLE
Added isPrivate field to TopicObject schema and handling in backend

### DIFF
--- a/public/openapi/components/schemas/TopicObject.yaml
+++ b/public/openapi/components/schemas/TopicObject.yaml
@@ -166,6 +166,9 @@ TopicObject:
         isAnon:
           nullable: true
           type: boolean
+        isPrivate:
+          nullable: true
+          type: boolean
         icons:
           type: array
           items:
@@ -238,6 +241,9 @@ TopicObjectSlim:
         lastposttime:
           type: number
         isAnon:
+          type: boolean
+          nullable: true
+        isPrivate:
           type: boolean
           nullable: true
         lastposttimeISO:

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -126,6 +126,7 @@ module.exports = function (Topics) {
             postcount: 0,
             viewcount: 0,
             isAnon: data.isAnon,
+            isPrivate: data.isPrivate,
         };
         if (Array.isArray(data.tags) && data.tags.length) {
             topicData.tags = data.tags.join(',');
@@ -182,7 +183,9 @@ module.exports = function (Topics) {
         data = await plugins_1.default.hooks.fire('filter:topic.post', data);
         const { uid } = data;
         const { isAnon } = data;
+        const { isPrivate } = data;
         data.isAnon = isAnon;
+        data.isPrivate = isPrivate;
         data.title = String(data.title).trim();
         data.tags = data.tags || [];
         if (data.content) {
@@ -268,7 +271,9 @@ module.exports = function (Topics) {
         const { tid } = data;
         const { uid } = data;
         const { isAnon } = data;
+        const { isPrivate } = data;
         data.isAnon = isAnon;
+        data.isPrivate = isPrivate;
         const topicData = await Topics.getTopicData(tid);
         await canReply(data, topicData);
         data.cid = topicData.cid;

--- a/src/topics/create.ts
+++ b/src/topics/create.ts
@@ -144,6 +144,7 @@ export = function (Topics: TopicMethods) {
             postcount: 0,
             viewcount: 0,
             isAnon: data.isAnon,
+            isPrivate: data.isPrivate,
         };
 
         if (Array.isArray(data.tags) && data.tags.length) {
@@ -207,8 +208,10 @@ export = function (Topics: TopicMethods) {
         data = await plugins.hooks.fire('filter:topic.post', data) as TopicData;
         const { uid } = data;
         const { isAnon } = data;
+        const { isPrivate } = data;
 
         data.isAnon = isAnon;
+        data.isPrivate = isPrivate;
 
         data.title = String(data.title).trim();
         data.tags = data.tags || [];
@@ -309,8 +312,10 @@ export = function (Topics: TopicMethods) {
         const { tid } = data;
         const { uid } = data;
         const { isAnon } = data;
+        const { isPrivate } = data;
 
         data.isAnon = isAnon;
+        data.isPrivate = isPrivate;
 
         const topicData = await Topics.getTopicData(tid);
 

--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -54,6 +54,9 @@ function modifyTopic(topic, fields) {
     if (topic.hasOwnProperty('isAnon')) {
         topic.isAnon = topic.isAnon === 'true';
     }
+    if (topic.hasOwnProperty('isPrivate')) {
+        topic.isPrivate = topic.isPrivate === 'true';
+    }
     if (fields.includes('teaserPid') || !fields.length) {
         topic.teaserPid = topic.teaserPid || null;
     }

--- a/src/topics/data.ts
+++ b/src/topics/data.ts
@@ -65,6 +65,10 @@ function modifyTopic(topic: OptionalTopic, fields: string[]) {
         topic.isAnon = topic.isAnon === 'true';
     }
 
+    if (topic.hasOwnProperty('isPrivate')) {
+        topic.isPrivate = topic.isPrivate === 'true';
+    }
+
     if (fields.includes('teaserPid') || !fields.length) {
         topic.teaserPid = topic.teaserPid || null;
     }

--- a/src/types/topic.ts
+++ b/src/types/topic.ts
@@ -16,6 +16,7 @@ export type TopicObject = {
   unreplied: boolean;
   icons: string[];
   isAnon?: boolean | string;
+  isPrivate?: boolean | string;
   tid?: number;
   thumb?: string;
   pinExpiry?: number;
@@ -63,6 +64,7 @@ export type TopicData = {
   postcount?: number | string;
   viewcount?: number | string;
   isAnon?: boolean | string;
+  isPrivate?: boolean | string;
   tags?: string | undefined[] | TagObject[];
   content?: string;
   fromQueue?: boolean;
@@ -110,6 +112,7 @@ export type TopicObjectOptionalProperties = {
   timestampISO: string;
   scheduled: boolean;
   isAnon: boolean;
+  isPrivate: boolean;
 };
 
 interface Teaser {


### PR DESCRIPTION
Resolves #32 

- Modified `public/openapi/components/schemas/TopicObject.yaml` to add `isPrivate` field to schema.
- Modified `src/topics/create.ts` to account for `isPrivate` field when creating a topic object.
- Modified `src/topics/data.ts` to convert `isPrivate` from string to boolean when getting data.
- Modified `src/types/topic.ts` to account for `isPrivate` field in Topics object.
- Passed lint/test locally when running `npm run lint` and `npm run test`.
