### PR TITLE
Fix patch-package error on install

### DIFF
--- a/install/package.json
+++ b/install/package.json
@@ -109,6 +109,7 @@
         "passport": "0.6.0",
         "passport-http-bearer": "1.0.1",
         "passport-local": "1.0.0",
+        "patch-package": "6.5.1",
         "pg": "8.8.0",
         "pg-cursor": "2.7.4",
         "postcss": "8.4.20",
@@ -172,7 +173,6 @@
         "mocha-lcov-reporter": "1.3.0",
         "mockdate": "3.0.5",
         "nyc": "15.1.0",
-        "patch-package": "6.5.1",
         "smtp-server": "3.11.0",
         "typescript": "^4.9.4"
     },


### PR DESCRIPTION
Move patch-package to dependencies from devDependencies

We were getting an error on `./nodebb setup` that patch-package was not found. `./nodebb setup` runs `npm install --omit=dev`, and since patch-package was in devDependencies it was not available when the `post-install` script ran. I moved patch-package  to dependencies, and we no longer have this issue.

Passed test/lint and manual testing.