### PR TITLE
Add submit as private button via composer plugin patch

### DIFF
--- a/patches/nodebb-plugin-composer-default+9.2.4.patch
+++ b/patches/nodebb-plugin-composer-default+9.2.4.patch
@@ -1,16 +1,17 @@
 diff --git a/node_modules/nodebb-plugin-composer-default/static/lib/composer.js b/node_modules/nodebb-plugin-composer-default/static/lib/composer.js
-index 46334e7..5d8b3ba 100644
+index 46334e7..2928eaa 100644
 --- a/node_modules/nodebb-plugin-composer-default/static/lib/composer.js
 +++ b/node_modules/nodebb-plugin-composer-default/static/lib/composer.js
-@@ -320,6 +320,7 @@ define('composer', [
+@@ -320,6 +320,8 @@ define('composer', [
  
  		var bodyEl = postContainer.find('textarea');
  		var submitBtn = postContainer.find('.composer-submit');
 +		var submitAnonBtn = postContainer.find('.composer-submit-anon');
++		var submitPrivateBtn = postContainer.find('.composer-submit-private');
  
  		categoryList.init(postContainer, composer.posts[post_uuid]);
  		scheduler.init(postContainer, composer.posts);
-@@ -348,6 +349,14 @@ define('composer', [
+@@ -348,6 +350,22 @@ define('composer', [
  			post(post_uuid);
  		});
  
@@ -22,82 +23,96 @@ index 46334e7..5d8b3ba 100644
 +			post(post_uuid, true);
 +		});
 +
++		submitPrivateBtn.on('click', function (e) {
++			e.preventDefault();
++			e.stopPropagation();	// Other click events bring composer back to active state which is undesired on submit
++
++			$(this).attr('disabled', true);
++			post(post_uuid, null, true);
++		});
++
  		require(['mousetrap'], function (mousetrap) {
  			mousetrap(postContainer.get(0)).bind('mod+enter', function () {
  				submitBtn.attr('disabled', true);
-@@ -622,7 +631,9 @@ define('composer', [
+@@ -622,7 +640,7 @@ define('composer', [
  		}, 20);
  	}
  
 -	async function post(post_uuid) {
-+	async function post(post_uuid, isAnon) {
-+		console.log("post method");
-+		console.log({isAnon});
++	async function post(post_uuid, isAnon, isPrivate) {
  		var postData = composer.posts[post_uuid];
  		var postContainer = $('.composer[data-uuid="' + post_uuid + '"]');
  		var handleEl = postContainer.find('.handle');
-@@ -631,6 +642,7 @@ define('composer', [
+@@ -631,6 +649,8 @@ define('composer', [
  		var thumbEl = postContainer.find('input#topic-thumb-url');
  		var onComposeRoute = postData.hasOwnProperty('template') && postData.template.compose === true;
  		const submitBtn = postContainer.find('.composer-submit');
 +		const submitAnonBtn = postContainer.find('.composer-submit-anon');
++		const submitPrivateBtn = postContainer.find('.composer-submit-private');
  
  		titleEl.val(titleEl.val().trim());
  		bodyEl.val(utils.rtrim(bodyEl.val()));
-@@ -696,6 +708,7 @@ define('composer', [
+@@ -696,6 +716,8 @@ define('composer', [
  				cid: categoryList.getSelectedCid(),
  				tags: tags.getTags(post_uuid),
  				timestamp: scheduler.getTimestamp(),
 +				isAnon,
++				isPrivate,
  			};
  		} else if (action === 'posts.reply') {
  			route = `/topics/${postData.tid}`;
-@@ -705,6 +718,7 @@ define('composer', [
+@@ -705,6 +727,8 @@ define('composer', [
  				handle: handleEl ? handleEl.val() : undefined,
  				content: bodyEl.val(),
  				toPid: postData.toPid,
 +				isAnon,
++				isPrivate,
  			};
  		} else if (action === 'posts.edit') {
  			method = 'put';
-@@ -718,6 +732,7 @@ define('composer', [
+@@ -718,6 +742,8 @@ define('composer', [
  				thumb: thumbEl.val() || '',
  				tags: tags.getTags(post_uuid),
  				timestamp: scheduler.getTimestamp(),
 +				isAnon,
++				isPrivate,
  			};
  		}
  		var submitHookData = {
-@@ -741,6 +756,7 @@ define('composer', [
+@@ -741,6 +767,8 @@ define('composer', [
  		api[method](route, composerData)
  			.then((data) => {
  				submitBtn.removeAttr('disabled');
 +				submitAnonBtn.removeAttr('disabled');
++				submitPrivateBtn.removeAttr('disabled');
  				postData.submitted = true;
  
  				composer.discard(post_uuid);
 diff --git a/node_modules/nodebb-plugin-composer-default/static/templates/compose.tpl b/node_modules/nodebb-plugin-composer-default/static/templates/compose.tpl
-index 8ce50b9..88f550b 100644
+index 8ce50b9..1bd78e4 100644
 --- a/node_modules/nodebb-plugin-composer-default/static/templates/compose.tpl
 +++ b/node_modules/nodebb-plugin-composer-default/static/templates/compose.tpl
-@@ -81,6 +81,8 @@
+@@ -81,6 +81,10 @@
  					<a href="{discardRoute}" class="btn btn-default composer-discard" data-action="discard" tabindex="-1"><i class="fa fa-times"></i> [[topic:composer.discard]]</a>
  
  					<button type="submit" form="compose-form" class="btn btn-primary composer-submit" data-action="post" tabindex="6" data-text-variant=" [[topic:composer.schedule]]"><i class="fa fa-check"></i> [[topic:composer.submit]]</button>
 +
 +					<button type="submit" form="compose-form" class="btn btn-info composer-submit-anon" data-action="post" tabindex="6" data-text-variant=" [[topic:composer.schedule]] as Anonymous"><i class="fa fa-check"></i> [[topic:composer.submit]] as Anonymous</button>
++				
++					<button type="submit" form="compose-form" class="btn btn-secondary composer-submit-private" data-action="post" tabindex="6" data-text-variant=" [[topic:composer.schedule]] as Private"><i class="fa fa-check"></i> [[topic:composer.submit]] as Private</button>
  				</div>
  			</div>
  		</div>
 diff --git a/node_modules/nodebb-plugin-composer-default/static/templates/composer.tpl b/node_modules/nodebb-plugin-composer-default/static/templates/composer.tpl
-index cf9de24..ad95601 100644
+index cf9de24..d49cf60 100644
 --- a/node_modules/nodebb-plugin-composer-default/static/templates/composer.tpl
 +++ b/node_modules/nodebb-plugin-composer-default/static/templates/composer.tpl
-@@ -56,6 +56,8 @@
+@@ -56,6 +56,9 @@
  
  				<ul class="dropdown-menu">{{{ each submitOptions }}}<li><a href="#" data-action="{./action}">{./text}</a></li>{{{ end }}}</ul>
  				<button class="btn btn-primary composer-submit" data-action="post" tabindex="6" data-text-variant=" [[topic:composer.schedule]]"><i class="fa fa-check"></i> [[topic:composer.submit]]</button>
 +				<button class="btn btn-info composer-submit-anon" data-action="post" tabindex="6" data-text-variant=" [[topic:composer.schedule]] as Anonymous"><i class="fa fa-check"></i> [[topic:composer.submit]] as Anonymous</button>
++				<button class="btn btn-secondary composer-submit-private" data-action="post" tabindex="6" data-text-variant=" [[topic:composer.schedule]] as Private"><i class="fa fa-check"></i> [[topic:composer.submit]] as Private</button>
 +
  				<button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
  					<span class="caret"></span>


### PR DESCRIPTION
Resolves #33. 
I added a Submit as Private button to the composer plugin which marks the `isPrivate` field as `true` when the form is submitted. 
I followed the same process as in #25.  
![image](https://user-images.githubusercontent.com/98926767/221094993-8c04e96d-d682-42f8-8f0f-9a9193364c77.png)
Passed test/lint and manual test.

 