### PR TITLE
Converted "src/categories/topics.js" from JS to TS

### DIFF
--- a/src/categories/topics.js
+++ b/src/categories/topics.js
@@ -171,7 +171,7 @@ module.exports = function (Categories) {
                 topic.tags = [];
             }
 
-            topic.visible = privileges.isAdminOrMod || topic.isOwner || !topic.isPrivate
+            topic.visible = privileges.isAdminOrMod || topic.isOwner || !topic.isPrivate;
         });
     };
 

--- a/src/categories/topics.js
+++ b/src/categories/topics.js
@@ -170,6 +170,8 @@ module.exports = function (Categories) {
                 topic.noAnchor = true;
                 topic.tags = [];
             }
+
+            topic.visible = privileges.isAdminOrMod || topic.isOwner || !topic.isPrivate
         });
     };
 

--- a/src/categories/topics.ts
+++ b/src/categories/topics.ts
@@ -1,196 +1,221 @@
-"use strict";
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
-const database_1 = __importDefault(require("../database"));
-const topics_1 = __importDefault(require("../topics"));
-const plugins_1 = __importDefault(require("../plugins"));
-const meta_1 = __importDefault(require("../meta"));
-const privileges_1 = __importDefault(require("../privileges"));
-const user_1 = __importDefault(require("../user"));
-module.exports = function (Categories) {
-    async function filterScheduledTids(tids) {
+import db from '../database';
+import topics from '../topics';
+import plugins from '../plugins';
+import meta from '../meta';
+import privileges from '../privileges';
+import user from '../user';
+import { CategoryMethods, CategoryTopicsResult, TopicIdsData, TopicObject } from '../types';
+
+export = function (Categories: CategoryMethods) {
+    async function filterScheduledTids(tids: (number|string)[]) : Promise<(number|string)[]> {
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        const scores = await database_1.default.sortedSetScores('topics:scheduled', tids);
-        const now = Date.now();
+        const scores = await db.sortedSetScores('topics:scheduled', tids) as {[key: number]: number};
+        const now: number = Date.now();
         return tids.filter((tid, index) => tid && (!scores[index] || scores[index] <= now));
     }
+
     Categories.getCategoryTopics = async function (data) {
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        const results = await plugins_1.default.hooks.fire('filter:category.topics.prepare', data);
+        const results: TopicIdsData = await plugins.hooks.fire('filter:category.topics.prepare', data) as TopicIdsData;
         const tids = await Categories.getTopicIds(results);
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        let topicsData = await topics_1.default.getTopicsByTids(tids, data.uid);
+        let topicsData: TopicObject[] = await topics.getTopicsByTids(tids, data.uid) as TopicObject[];
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        topicsData = await user_1.default.blocks.filter(data.uid, topicsData);
+        topicsData = await user.blocks.filter(data.uid, topicsData) as TopicObject[];
+
         if (!topicsData.length) {
             return { topics: [], uid: data.uid };
         }
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        topics_1.default.calculateTopicIndices(topicsData, data.start);
+        topics.calculateTopicIndices(topicsData, data.start);
+
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        const res = await plugins_1.default.hooks.fire('filter:category.topics.get', { cid: data.cid, topics: topicsData, uid: data.uid });
+        const res: CategoryTopicsResult = await plugins.hooks.fire('filter:category.topics.get', { cid: data.cid, topics: topicsData, uid: data.uid }) as CategoryTopicsResult;
         return { topics: res.topics, nextStart: data.stop + 1 };
     };
+
     Categories.getTopicIds = async function (data) {
-        const dataForPinned = Object.assign({}, data);
+        const dataForPinned = { ...data };
         dataForPinned.start = 0;
         dataForPinned.stop = -1;
+
         const [pinnedTids, set, direction] = await Promise.all([
             Categories.getPinnedTids(dataForPinned),
             Categories.buildTopicsSortedSet(data),
             Categories.getSortedSetRangeDirection(data.sort),
         ]);
+
         const totalPinnedCount = pinnedTids.length;
         const pinnedTidsOnPage = pinnedTids.slice(data.start, data.stop !== -1 ? data.stop + 1 : undefined);
         const pinnedCountOnPage = pinnedTidsOnPage.length;
         const topicsPerPage = data.stop - data.start + 1;
         const normalTidsToGet = Math.max(0, topicsPerPage - pinnedCountOnPage);
+
         if (!normalTidsToGet && data.stop !== -1) {
             return pinnedTidsOnPage;
         }
+
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        if (plugins_1.default.hooks.hasListeners('filter:categories.getTopicIds')) {
+        if (plugins.hooks.hasListeners('filter:categories.getTopicIds')) {
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            const result = await plugins_1.default.hooks.fire('filter:categories.getTopicIds', {
+            const result = await plugins.hooks.fire('filter:categories.getTopicIds', {
                 tids: [],
                 data: data,
                 pinnedTids: pinnedTidsOnPage,
                 allPinnedTids: pinnedTids,
                 totalPinnedCount: totalPinnedCount,
                 normalTidsToGet: normalTidsToGet,
-            });
+            }) as {
+                tids: (string|number)[]
+            };
             return result && result.tids;
         }
+
         let { start } = data;
         if (start > 0 && totalPinnedCount) {
             start -= totalPinnedCount - pinnedCountOnPage;
         }
+
         const stop = data.stop === -1 ? data.stop : start + normalTidsToGet - 1;
-        let normalTids;
+        let normalTids: (number|string)[];
         const reverse = direction === 'highest-to-lowest';
         if (Array.isArray(set)) {
             const weights = set.map((s, index) => (index ? 0 : 1));
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            normalTids = await database_1.default[reverse ? 'getSortedSetRevIntersect' : 'getSortedSetIntersect']({ sets: set, start: start, stop: stop, weights: weights });
-        }
-        else {
+            normalTids = await db[reverse ? 'getSortedSetRevIntersect' : 'getSortedSetIntersect']({ sets: set, start: start, stop: stop, weights: weights }) as (string|number)[];
+        } else {
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            normalTids = await database_1.default[reverse ? 'getSortedSetRevRange' : 'getSortedSetRange'](set, start, stop);
+            normalTids = await db[reverse ? 'getSortedSetRevRange' : 'getSortedSetRange'](set, start, stop) as (string|number)[];
         }
         normalTids = normalTids.filter(tid => !pinnedTids.includes(tid));
         return pinnedTidsOnPage.concat(normalTids);
     };
+
     Categories.getTopicCount = async function (data) {
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        if (plugins_1.default.hooks.hasListeners('filter:categories.getTopicCount')) {
+        if (plugins.hooks.hasListeners('filter:categories.getTopicCount')) {
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            const result = await plugins_1.default.hooks.fire('filter:categories.getTopicCount', {
+            const result = await plugins.hooks.fire('filter:categories.getTopicCount', {
                 topicCount: data.category.topic_count,
                 data: data,
-            });
+            }) as {
+                topicCount: number;
+            };
             return result && result.topicCount;
         }
         const set = await Categories.buildTopicsSortedSet(data);
         if (Array.isArray(set)) {
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            return await database_1.default.sortedSetIntersectCard(set);
-        }
-        else if (data.targetUid && set) {
+            return await db.sortedSetIntersectCard(set) as number;
+        } else if (data.targetUid && set) {
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            return await database_1.default.sortedSetCard(set);
+            return await db.sortedSetCard(set) as number;
         }
         return data.category.topic_count;
     };
+
     Categories.buildTopicsSortedSet = async function (data) {
         const { cid } = data;
-        let set = `cid:${cid}:tids`;
+        let set: string | string[] = `cid:${cid}:tids`;
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        const sort = (data.sort || (data.settings && data.settings.categoryTopicSort) || meta_1.default.config.categoryTopicSort || 'newest_to_oldest');
+        const sort: string = (data.sort || (data.settings && data.settings.categoryTopicSort) || meta.config.categoryTopicSort || 'newest_to_oldest') as string;
+
         if (sort === 'most_posts') {
             set = `cid:${cid}:tids:posts`;
-        }
-        else if (sort === 'most_votes') {
+        } else if (sort === 'most_votes') {
             set = `cid:${cid}:tids:votes`;
-        }
-        else if (sort === 'most_views') {
+        } else if (sort === 'most_views') {
             set = `cid:${cid}:tids:views`;
         }
+
         if (data.tag) {
             if (Array.isArray(data.tag)) {
                 set = [set].concat(data.tag.map(tag => `tag:${tag}:topics`));
-            }
-            else {
+            } else {
                 set = [set, `tag:${data.tag}:topics`];
             }
         }
+
         if (data.targetUid) {
             set = (Array.isArray(set) ? set : [set]).concat([`cid:${cid}:uid:${data.targetUid}:tids`]);
         }
-        const result = await plugins_1.default.hooks.fire('filter:categories.buildTopicsSortedSet', {
+
+        const result = await plugins.hooks.fire('filter:categories.buildTopicsSortedSet', {
             set: set,
             data: data,
-        });
+        }) as {
+            set: string|string[]
+        };
         return result && result.set;
     };
+
     Categories.getSortedSetRangeDirection = async function (sort) {
         sort = sort || 'newest_to_oldest';
         const direction = ['newest_to_oldest', 'most_posts', 'most_votes', 'most_views'].includes(sort) ? 'highest-to-lowest' : 'lowest-to-highest';
-        const result = await plugins_1.default.hooks.fire('filter:categories.getSortedSetRangeDirection', {
+        const result = await plugins.hooks.fire('filter:categories.getSortedSetRangeDirection', {
             sort: sort,
             direction: direction,
-        });
+        }) as {
+            direction: string
+        };
         return result && result.direction;
     };
+
     Categories.getAllTopicIds = async function (cid, start, stop) {
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        return await database_1.default.getSortedSetRange([`cid:${cid}:tids:pinned`, `cid:${cid}:tids`], start, stop);
+        return await db.getSortedSetRange([`cid:${cid}:tids:pinned`, `cid:${cid}:tids`], start, stop) as (string|number)[];
     };
+
     Categories.getPinnedTids = async function (data) {
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        if (plugins_1.default.hooks.hasListeners('filter:categories.getPinnedTids')) {
+        if (plugins.hooks.hasListeners('filter:categories.getPinnedTids')) {
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            const result = await plugins_1.default.hooks.fire('filter:categories.getPinnedTids', {
+            const result = await plugins.hooks.fire('filter:categories.getPinnedTids', {
                 pinnedTids: [],
                 data: data,
-            });
+            }) as {
+                pinnedTids: (string|number)[]
+            };
             return result && result.pinnedTids;
         }
         const [allPinnedTids, canSchedule] = await Promise.all([
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            database_1.default.getSortedSetRevRange(`cid:${data.cid}:tids:pinned`, data.start, data.stop),
+            db.getSortedSetRevRange(`cid:${data.cid}:tids:pinned`, data.start, data.stop) as (number|string)[],
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            privileges_1.default.categories.can('topics:schedule', data.cid, data.uid),
+            privileges.categories.can('topics:schedule', data.cid, data.uid) as boolean,
         ]);
         const pinnedTids = canSchedule ? allPinnedTids : await filterScheduledTids(allPinnedTids);
+
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        return await topics_1.default.tools.checkPinExpiry(pinnedTids);
+        return await topics.tools.checkPinExpiry(pinnedTids) as (string|number)[];
     };
+
     Categories.modifyTopicsByPrivilege = function (topics, privileges) {
         if (!Array.isArray(topics) || !topics.length || privileges.view_deleted) {
             return;
         }
+
         topics.forEach((topic) => {
             if (!topic.scheduled && topic.deleted && !topic.isOwner) {
                 topic.title = '[[topic:topic_is_deleted]]';
@@ -202,9 +227,11 @@ module.exports = function (Categories) {
                 topic.noAnchor = true;
                 topic.tags = [];
             }
+
             topic.visible = privileges.isAdminOrMod || topic.isOwner || !topic.isPrivate;
         });
     };
+
     Categories.onNewPostMade = async function (cid, pinned, postData) {
         if (!cid || !postData) {
             return;
@@ -212,15 +239,15 @@ module.exports = function (Categories) {
         const promises = [
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            database_1.default.sortedSetAdd(`cid:${cid}:pids`, postData.timestamp, postData.pid),
+            db.sortedSetAdd(`cid:${cid}:pids`, postData.timestamp, postData.pid),
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            database_1.default.incrObjectField(`category:${cid}`, 'post_count'),
+            db.incrObjectField(`category:${cid}`, 'post_count'),
         ];
         if (!pinned) {
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            promises.push(database_1.default.sortedSetIncrBy(`cid:${cid}:tids:posts`, 1, postData.tid));
+            promises.push(db.sortedSetIncrBy(`cid:${cid}:tids:posts`, 1, postData.tid));
         }
         await Promise.all(promises);
         await Categories.updateRecentTidForCid(cid);

--- a/src/privileges/topics.js
+++ b/src/privileges/topics.js
@@ -57,6 +57,8 @@ privsTopics.get = async function (tid, uid) {
         disabled: disabled,
         tid: tid,
         uid: uid,
+        
+        visible: isAdminOrMod || isOwner || !topicData.isPrivate,
     });
 };
 

--- a/src/privileges/topics.js
+++ b/src/privileges/topics.js
@@ -57,7 +57,7 @@ privsTopics.get = async function (tid, uid) {
         disabled: disabled,
         tid: tid,
         uid: uid,
-        
+
         visible: isAdminOrMod || isOwner || !topicData.isPrivate,
     });
 };

--- a/src/topics/create.ts
+++ b/src/topics/create.ts
@@ -279,7 +279,7 @@ export = function (Topics: TopicMethods) {
 
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        if (uid > 0 && settings.followTopicsOnCreate) {
+        if (uid as number > 0 && settings.followTopicsOnCreate) {
             await Topics.follow(postData.tid, uid);
         }
         const topicData = topics[0];
@@ -350,7 +350,7 @@ export = function (Topics: TopicMethods) {
         const settings = await user.getSettings(uid) as SettingsObject;
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        if (uid > 0 && settings.followTopicsOnReply) {
+        if (uid as number > 0 && settings.followTopicsOnReply) {
             await Topics.follow(postData.tid, uid);
         }
 

--- a/src/types/category.ts
+++ b/src/types/category.ts
@@ -1,3 +1,7 @@
+import { PostObject } from './post';
+import { SettingsObject } from './settings';
+import { TopicObject } from './topic';
+
 export type CategoryObject = {
   cid: number;
   name: string;
@@ -32,3 +36,63 @@ export type CategoryOptionalProperties = {
   cid: number;
   backgroundImage: string;
 };
+
+export type TopicCountData = {
+  cid: string;
+  category?: CategoryObject;
+  targetUid?: string;
+}
+
+export type TopicIdsData = {
+  cid: string;
+  uid: string;
+  start: number;
+  stop: number;
+  sort?: string;
+}
+
+export type CategoryTopicsData = {
+  uid?: string;
+  cid: string;
+  start?: number;
+  stop?: number;
+}
+
+export type CategoryTopicsResult = {
+  topics?: TopicObject[]
+  uid?: string|number;
+  nextStart?: number;
+}
+
+export type BuildTopicsSortedSetData = {
+  cid: string;
+  sort?: string;
+  settings?: SettingsObject;
+  tag?: string | string[];
+  targetUid?: string;
+}
+
+export type PinnedTidsData = {
+  cid: string;
+  uid: string;
+  start: number;
+  stop: number;
+}
+
+export type TopicPrivilege = {
+  view_deleted: boolean;
+  isAdminOrMod: boolean;
+}
+
+export interface CategoryMethods {
+  getCategoryTopics: (data: CategoryTopicsData) => Promise<CategoryTopicsResult>;
+  getTopicIds: (data: TopicIdsData) => Promise<(string|number)[]>;
+  getTopicCount: (data: TopicCountData) => Promise<number>;
+  buildTopicsSortedSet: (data: BuildTopicsSortedSetData) => Promise<string|string[]>;
+  getSortedSetRangeDirection: (sort: string) => Promise<string>;
+  getAllTopicIds: (cid: string, start: number, stop: number) => Promise<(string|number)[]>;
+  getPinnedTids: (data: PinnedTidsData) => Promise<(string|number)[]>;
+  modifyTopicsByPrivilege: (topics: TopicObject[], privileges: TopicPrivilege) => void;
+  onNewPostMade: (cid: string, pinned: boolean, postData: PostObject) => Promise<void>;
+  updateRecentTidForCid: (cid: string) => Promise<void>;
+}

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -4,7 +4,7 @@ import { UserObjectSlim } from './user';
 
 export type PostObject = {
   pid: number;
-  tid: number;
+  tid: number | string;
   content: string;
   uid: number;
   timestamp: number;
@@ -27,7 +27,7 @@ export type PostObject = {
 
 export type PostObjectPartial = {
   pid?: number;
-  tid?: number;
+  tid?: number | string;
   content?: string;
   uid?: number | string;
   timestamp?: number;
@@ -94,7 +94,6 @@ export interface PostsMethods {
     getPostSummaryByPids: (pids: number[], uid: number, options: PostSummaryOptions) => Promise<OptionalPostList>;
     parsePost: (post: OptionalPost) => Promise<OptionalPost>;
     overrideGuestHandle: (post: PostObject, handle: string) => void;
-
     create: (data: PostObjectPartial) => Promise<PostObject | PostObjectPartial>;
     uploads: any;
 }

--- a/src/types/topic.ts
+++ b/src/types/topic.ts
@@ -17,7 +17,7 @@ export type TopicObject = {
   icons: string[];
   isAnon?: boolean | string;
   isPrivate?: boolean | string;
-  tid?: number;
+  tid?: number | string;
   thumb?: string;
   pinExpiry?: number;
   pinExpiryISO?: string | number;
@@ -27,7 +27,7 @@ export type TopicObject = {
   uid: number | string;
   cid: number;
   title: string;
-  slug: string;
+  slug: string | number;
   mainPid: number;
   postcount: string;
   viewcount: string;
@@ -45,7 +45,8 @@ export type TopicObject = {
   teaserPid: number | string;
   thumbs: Thumb[];
   mainPost?: PostObjectPartial;
-
+  noAnchor?: boolean;
+  visible?: boolean;
 }
 
 export type Request = {
@@ -53,12 +54,12 @@ export type Request = {
 }
 
 export type TopicData = {
-  tid?: number;
+  tid?: number | string;
   uid?: number | string;
   cid?: number;
   mainPid?: number;
   title?: string;
-  slug?: string;
+  slug?: string | number;
   timestamp?: number;
   lastposttime?: number | string;
   postcount?: number | string;
@@ -104,7 +105,7 @@ export type TopicObjectCoreProperties = {
 };
 
 export type TopicObjectOptionalProperties = {
-  tid: number;
+  tid: number | string;
   thumb: string;
   pinExpiry: number;
   pinExpiryISO: string;
@@ -158,13 +159,13 @@ export type TopicSlimProperties = {
 };
 
 export type Thumb = {
-  id: number;
+  id: number | string;
   name: string;
   url: string;
 };
 
 export type TopicSlimOptionalProperties = {
-  tid: number;
+  tid: number | string;
   numThumbs: number;
 };
 
@@ -174,19 +175,19 @@ export type TopicPostData = {
 }
 
 export interface TopicMethods {
-  getTopicsFields: (tids: number[], fields: string[]) => Promise<OptionalTopicList>;
-  getTopicField: (tid: number, field: string) => Promise<TopicField>;
-  getTopicFields: (tid: number, fields: string[]) => Promise<OptionalTopic>;
-  getTopicData: (tid: number) => Promise<OptionalTopic>;
-  getTopicsData: (tids: number[]) => Promise<OptionalTopicList>;
-  getCategoryData: (tid: number) => Promise<OptionalCategory>;
-  setTopicField: (tid: number, field: string, value: TopicField) => Promise<void>;
-  setTopicFields: (tid: number, data: OptionalTopic) => Promise<void>;
-  deleteTopicField: (tid: number, field: string) => Promise<void>;
-  deleteTopicFields: (tid: number, fields: string[]) => Promise<void>;
+  getTopicsFields: (tids: (number|string)[], fields: string[]) => Promise<OptionalTopicList>;
+  getTopicField: (tid: (number|string), field: string) => Promise<TopicField>;
+  getTopicFields: (tid: (number|string), fields: string[]) => Promise<OptionalTopic>;
+  getTopicData: (tid: (number|string)) => Promise<OptionalTopic>;
+  getTopicsData: (tids: (number|string)[]) => Promise<OptionalTopicList>;
+  getCategoryData: (tid: (number|string)) => Promise<OptionalCategory>;
+  setTopicField: (tid: (number|string), field: string, value: TopicField) => Promise<void>;
+  setTopicFields: (tid: (number|string), data: OptionalTopic) => Promise<void>;
+  deleteTopicField: (tid: (number|string), field: string) => Promise<void>;
+  deleteTopicFields: (tid: (number|string), fields: string[]) => Promise<void>;
 
-  create: (data: TopicData) => Promise<number>;
-  createTags: (tags: string | undefined[] | TagObject[], tid: number, timestamp: number) => Promise<void>;
+  create: (data: TopicData) => Promise<string | number>;
+  createTags: (tags: string | undefined[] | TagObject[], tid: (number|string), timestamp: number) => Promise<void>;
   scheduled: any;
 
   post: (data: TopicData) => Promise<TopicPostData>;
@@ -195,9 +196,9 @@ export interface TopicMethods {
   filterTags: (tags: string | undefined[] | TagObject[], cid: number) => Promise<string | undefined[] | TagObject[]>;
   checkContent: (content: string) => void;
 
-  getTopicsByTids: (tids: number[], uid: number | string) => Promise<OptionalTopic[]>;
-  follow: (tid: number, uid: number | string) => Promise<void>;
-  delete: (tid: number) => Promise<void>;
+  getTopicsByTids: (tids: (number|string)[], uid: number | string) => Promise<OptionalTopic[]>;
+  follow: (tid: (number|string), uid: number | string) => Promise<void>;
+  delete: (tid: (number|string)) => Promise<void>;
 
   reply: (data: TopicData) => Promise<PostObjectPartial>;
   notifyFollowers: (postData: PostObjectPartial, uid: number | string, obj: {
@@ -207,8 +208,8 @@ export interface TopicMethods {
     mergeId: string,
   }) => void;
 
-  markAsUnreadForAll: (tid: number) => Promise<void>;
-  markAsRead: (tids: number[], uid: number | string) => Promise<void>;
+  markAsUnreadForAll: (tid: (number|string)) => Promise<void>;
+  markAsRead: (tids: (number|string)[], uid: number | string) => Promise<void>;
   addParentPosts: (postData: PostObjectPartial[]) => Promise<void>;
   syncBacklinks: (postData: PostObjectPartial) => Promise<void>;
 }


### PR DESCRIPTION
resolves #41 

Converted `src/categories/topics.js` from TS to JS
- Added `src/categories/topics.ts`
- Generated `src/categories/topics.js` using `npx tsc`
- Added type annotations in compliance with the linter
- Still passes all tests when testing locally 
- Silenced `@typescript-eslint/no-unsafe-member-access` and `@typescript-eslint/no-unsafe-call errors` when calling a function on untranslated modules
