### PR TITLE
Converted "src/privileges/topics.js" from JS to TS

### DIFF
--- a/src/categories/topics.js
+++ b/src/categories/topics.js
@@ -171,7 +171,7 @@ module.exports = function (Categories) {
                 topic.tags = [];
             }
 
-            topic.visible = privileges.isAdminOrMod || topic.isOwner || !topic.isPrivate
+            topic.visible = privileges.isAdminOrMod || topic.isOwner || !topic.isPrivate;
         });
     };
 

--- a/src/categories/topics.js
+++ b/src/categories/topics.js
@@ -170,6 +170,8 @@ module.exports = function (Categories) {
                 topic.noAnchor = true;
                 topic.tags = [];
             }
+
+            topic.visible = privileges.isAdminOrMod || topic.isOwner || !topic.isPrivate
         });
     };
 

--- a/src/privileges/topics.js
+++ b/src/privileges/topics.js
@@ -57,6 +57,8 @@ privsTopics.get = async function (tid, uid) {
         disabled: disabled,
         tid: tid,
         uid: uid,
+        
+        visible: isAdminOrMod || isOwner || !topicData.isPrivate,
     });
 };
 

--- a/src/privileges/topics.js
+++ b/src/privileges/topics.js
@@ -57,7 +57,7 @@ privsTopics.get = async function (tid, uid) {
         disabled: disabled,
         tid: tid,
         uid: uid,
-        
+
         visible: isAdminOrMod || isOwner || !topicData.isPrivate,
     });
 };

--- a/src/privileges/topics.ts
+++ b/src/privileges/topics.ts
@@ -1,66 +1,68 @@
-"use strict";
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.canEdit = exports.isOwnerOrAdminOrMod = exports.isAdminOrMod = exports.canDelete = exports.canPurge = exports.filterUids = exports.filterTids = exports.can = exports.get = exports.canViewDeletedScheduled = void 0;
-const lodash_1 = __importDefault(require("lodash"));
-const meta_1 = __importDefault(require("../meta"));
-const topics_1 = __importDefault(require("../topics"));
-const user_1 = __importDefault(require("../user"));
-const helpers_1 = __importDefault(require("./helpers"));
-const categories_1 = __importDefault(require("../categories"));
-const plugins_1 = __importDefault(require("../plugins"));
-const categories_2 = __importDefault(require("./categories"));
-function canViewDeletedScheduled(topic, privileges = {}, viewDeleted = false, viewScheduled = false) {
+import _ from 'lodash';
+import meta from '../meta';
+import topics from '../topics';
+import user from '../user';
+import helpers from './helpers';
+import categories from '../categories';
+import plugins from '../plugins';
+import privsCategories from './categories';
+import { CategoryObject, TopicObject } from '../types';
+
+export function canViewDeletedScheduled(topic: TopicObject,
+    privileges: {view_deleted?: boolean, view_scheduled?: boolean} = {},
+    viewDeleted = false, viewScheduled = false) {
     if (!topic) {
         return false;
     }
     const { deleted = false, scheduled = false } = topic;
     const { view_deleted = viewDeleted, view_scheduled = viewScheduled } = privileges;
+
     // conceptually exclusive, scheduled topics deemed to be not deleted (they can only be purged)
     if (scheduled) {
         return view_scheduled;
-    }
-    else if (deleted) {
+    } else if (deleted) {
         return view_deleted;
     }
+
     return true;
 }
-exports.canViewDeletedScheduled = canViewDeletedScheduled;
-async function get(tid, uid) {
-    uid = parseInt(uid, 10);
+
+export async function get(tid: string, uid: string | number) : Promise<TopicObject> {
+    uid = parseInt(uid as string, 10);
+
     const privs = [
         'topics:reply', 'topics:read', 'topics:schedule', 'topics:tag',
         'topics:delete', 'posts:edit', 'posts:history',
         'posts:delete', 'posts:view_deleted', 'read', 'purge',
     ];
+
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    const topicData = await topics_1.default.getTopicFields(tid, ['cid', 'uid', 'locked', 'deleted', 'scheduled']);
+    const topicData: TopicObject = await topics.getTopicFields(tid, ['cid', 'uid', 'locked', 'deleted', 'scheduled']) as TopicObject;
     const [userPrivileges, isAdministrator, isModerator, disabled] = await Promise.all([
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        helpers_1.default.isAllowedTo(privs, uid, topicData.cid),
+        helpers.isAllowedTo(privs, uid, topicData.cid) as boolean[],
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        user_1.default.isAdministrator(uid),
+        user.isAdministrator(uid) as boolean,
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        user_1.default.isModerator(uid, topicData.cid),
+        user.isModerator(uid, topicData.cid) as boolean,
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        categories_1.default.getCategoryField(topicData.cid, 'disabled'),
+        categories.getCategoryField(topicData.cid, 'disabled') as boolean,
     ]);
-    const privData = lodash_1.default.zipObject(privs, userPrivileges);
+    const privData : {[key: string]: boolean} = _.zipObject(privs, userPrivileges);
     const isOwner = uid > 0 && uid === topicData.uid;
     const isAdminOrMod = isAdministrator || isModerator;
     const editable = isAdminOrMod;
     const deletable = (privData['topics:delete'] && (isOwner || isModerator)) || isAdministrator;
     const mayReply = canViewDeletedScheduled(topicData, {}, false, privData['topics:schedule']);
+
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    return await plugins_1.default.hooks.fire('filter:privileges.topics.get', {
+    return await plugins.hooks.fire('filter:privileges.topics.get', {
         'topics:reply': (privData['topics:reply'] && ((!topicData.locked && mayReply) || isModerator)) || isAdministrator,
         'topics:read': privData['topics:read'] || isAdministrator,
         'topics:schedule': privData['topics:schedule'] || isAdministrator,
@@ -72,6 +74,7 @@ async function get(tid, uid) {
         'posts:view_deleted': privData['posts:view_deleted'] || isAdministrator,
         read: privData.read || isAdministrator,
         purge: (privData.purge && (isOwner || isModerator)) || isAdministrator,
+
         view_thread_tools: editable || deletable,
         editable: editable,
         deletable: deletable,
@@ -81,157 +84,185 @@ async function get(tid, uid) {
         disabled: disabled,
         tid: tid,
         uid: uid,
+
         visible: isAdminOrMod || isOwner || !topicData.isPrivate,
-    });
+    }) as TopicObject;
 }
-exports.get = get;
-async function can(privilege, tid, uid) {
+
+export async function can(privilege: string, tid: string | number, uid: string | number) {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    const cid = await topics_1.default.getTopicField(tid, 'cid');
+    const cid: (string | number) = await topics.getTopicField(tid, 'cid') as (string | number);
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    return await categories_2.default.can(privilege, cid, uid);
+    return await privsCategories.can(privilege, cid, uid) as boolean;
 }
-exports.can = can;
-async function filterTids(privilege, tids, uid) {
+
+export async function filterTids(privilege: string, tids: (number | string)[], uid: (number | string)) {
     if (!Array.isArray(tids) || !tids.length) {
         return [];
     }
+
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    const topicsData = await topics_1.default.getTopicsFields(tids, ['tid', 'cid', 'deleted', 'scheduled']);
-    const cids = lodash_1.default.uniq(topicsData.map(topic => topic.cid));
+    const topicsData = await topics.getTopicsFields(tids, ['tid', 'cid', 'deleted', 'scheduled']) as TopicObject[];
+    const cids = _.uniq(topicsData.map(topic => topic.cid));
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    const results = await categories_2.default.getBase(privilege, cids, uid);
-    const allowedCids = cids.filter((cid, index) => (!results.categories[index].disabled &&
-        (results.allowedTo[index] || results.isAdmin)));
+    const results = await privsCategories.getBase(privilege, cids, uid) as {
+        categories: CategoryObject[];
+        allowedTo: boolean[];
+        isAdmin: boolean[];
+        view_deleted: boolean[];
+        view_scheduled: boolean[];
+    };
+
+    const allowedCids = cids.filter((cid, index) => (
+        !results.categories[index].disabled &&
+        (results.allowedTo[index] || results.isAdmin)
+    ));
+
     const cidsSet = new Set(allowedCids);
-    const canViewDeleted = lodash_1.default.zipObject(cids, results.view_deleted);
-    const canViewScheduled = lodash_1.default.zipObject(cids, results.view_scheduled);
-    tids = topicsData.filter(t => (cidsSet.has(t.cid) &&
-        (results.isAdmin || canViewDeletedScheduled(t, {}, canViewDeleted[t.cid], canViewScheduled[t.cid])))).map(t => t.tid);
+    const canViewDeleted : {[key: number]: boolean} = _.zipObject(cids, results.view_deleted);
+    const canViewScheduled : {[key: number]: boolean} = _.zipObject(cids, results.view_scheduled);
+
+    tids = topicsData.filter(t => (
+        cidsSet.has(t.cid) &&
+        (results.isAdmin || canViewDeletedScheduled(t, {}, canViewDeleted[t.cid], canViewScheduled[t.cid]))
+    )).map(t => t.tid);
+
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    const data = await plugins_1.default.hooks.fire('filter:privileges.topics.filter', {
+    const data = await plugins.hooks.fire('filter:privileges.topics.filter', {
         privilege: privilege,
         uid: uid,
         tids: tids,
-    });
+    }) as {
+        tids: (number | string)[]
+    };
     return data ? data.tids : [];
 }
-exports.filterTids = filterTids;
-async function filterUids(privilege, tid, uids) {
+
+export async function filterUids(privilege: string, tid: (number | string), uids: (number|string)[]) {
     if (!Array.isArray(uids) || !uids.length) {
         return [];
     }
-    uids = lodash_1.default.uniq(uids);
+
+    uids = _.uniq(uids);
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    const topicData = await topics_1.default.getTopicFields(tid, ['tid', 'cid', 'deleted', 'scheduled']);
+    const topicData = await topics.getTopicFields(tid, ['tid', 'cid', 'deleted', 'scheduled']) as TopicObject;
     const [disabled, allowedTo, isAdmins] = await Promise.all([
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        categories_1.default.getCategoryField(topicData.cid, 'disabled'),
+        categories.getCategoryField(topicData.cid, 'disabled') as boolean[],
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        helpers_1.default.isUsersAllowedTo(privilege, uids, topicData.cid),
+        helpers.isUsersAllowedTo(privilege, uids, topicData.cid) as boolean[],
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        user_1.default.isAdministrator(uids),
+        user.isAdministrator(uids) as boolean[],
     ]);
+
     if (topicData.scheduled) {
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        const canViewScheduled = await helpers_1.default.isUsersAllowedTo('topics:schedule', uids, topicData.cid);
+        const canViewScheduled = await helpers.isUsersAllowedTo('topics:schedule', uids, topicData.cid) as {[key: number]: boolean};
         uids = uids.filter((uid, index) => canViewScheduled[index]);
     }
+
     return uids.filter((uid, index) => !disabled &&
-        ((allowedTo[index] && (topicData.scheduled || !topicData.deleted)) || isAdmins[index]));
+            ((allowedTo[index] && (topicData.scheduled || !topicData.deleted)) || isAdmins[index]));
 }
-exports.filterUids = filterUids;
-async function canPurge(tid, uid) {
+
+export async function canPurge(tid: (number | string), uid: (number | string)) {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    const cid = await topics_1.default.getTopicField(tid, 'cid');
+    const cid = await topics.getTopicField(tid, 'cid') as (number | string);
     const [purge, owner, isAdmin, isModerator] = await Promise.all([
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        categories_2.default.isUserAllowedTo('purge', cid, uid),
+        privsCategories.isUserAllowedTo('purge', cid, uid) as boolean,
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        topics_1.default.isOwner(tid, uid),
+        topics.isOwner(tid, uid) as boolean,
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        user_1.default.isAdministrator(uid),
+        user.isAdministrator(uid) as boolean,
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        user_1.default.isModerator(uid, cid),
+        user.isModerator(uid, cid) as boolean,
     ]);
     return (purge && (owner || isModerator)) || isAdmin;
 }
-exports.canPurge = canPurge;
-async function canDelete(tid, uid) {
+
+export async function canDelete(tid: (number | string), uid: (number | string)): Promise<boolean> {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    const topicData = await topics_1.default.getTopicFields(tid, ['uid', 'cid', 'postcount', 'deleterUid']);
+    const topicData = await topics.getTopicFields(tid, ['uid', 'cid', 'postcount', 'deleterUid']) as TopicObject;
     const [isModerator, isAdministrator, isOwner, allowedTo] = await Promise.all([
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        user_1.default.isModerator(uid, topicData.cid),
+        user.isModerator(uid, topicData.cid) as boolean,
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        user_1.default.isAdministrator(uid),
+        user.isAdministrator(uid) as boolean,
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        topics_1.default.isOwner(tid, uid),
+        topics.isOwner(tid, uid) as boolean,
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        helpers_1.default.isAllowedTo('topics:delete', uid, [topicData.cid]),
+        helpers.isAllowedTo('topics:delete', uid, [topicData.cid]) as boolean,
     ]);
+
     if (isAdministrator) {
         return true;
     }
+
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    const { preventTopicDeleteAfterReplies } = meta_1.default.config;
+    const { preventTopicDeleteAfterReplies } = meta.config as { preventTopicDeleteAfterReplies: number | null};
     if (!isModerator && preventTopicDeleteAfterReplies &&
-        (topicData.postcount - 1) >= preventTopicDeleteAfterReplies) {
+        (topicData.postcount as number - 1) >= preventTopicDeleteAfterReplies) {
         const langKey = preventTopicDeleteAfterReplies > 1 ?
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            `[[error:cant-delete-topic-has-replies, ${meta_1.default.config.preventTopicDeleteAfterReplies}]]` :
+            `[[error:cant-delete-topic-has-replies, ${meta.config.preventTopicDeleteAfterReplies as string}]]` :
             '[[error:cant-delete-topic-has-reply]]';
         throw new Error(langKey);
     }
+
     const { deleterUid } = topicData;
     return allowedTo[0] && ((isOwner && (deleterUid === 0 || deleterUid === topicData.uid)) || isModerator);
 }
-exports.canDelete = canDelete;
-async function isAdminOrMod(tid, uid) {
-    if (parseInt(uid, 10) <= 0) {
+
+export async function isAdminOrMod(tid: (number | string), uid: (number | string)): Promise<boolean> {
+    if (parseInt(uid as string, 10) <= 0) {
         return false;
     }
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    const cid = await topics_1.default.getTopicField(tid, 'cid');
+    const cid = await topics.getTopicField(tid, 'cid') as (number | string);
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    return await categories_2.default.isAdminOrMod(cid, uid);
+    return await privsCategories.isAdminOrMod(cid, uid) as boolean;
 }
-exports.isAdminOrMod = isAdminOrMod;
-async function isOwnerOrAdminOrMod(tid, uid) {
+
+
+export async function isOwnerOrAdminOrMod(tid: (number | string), uid: (number | string)) {
     const [isOwner, isAdminOrM] = await Promise.all([
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        topics_1.default.isOwner(tid, uid),
+        topics.isOwner(tid, uid) as boolean,
         isAdminOrMod(tid, uid),
     ]);
     return isOwner || isAdminOrM;
 }
-exports.isOwnerOrAdminOrMod = isOwnerOrAdminOrMod;
-async function canEdit(tid, uid) {
+
+
+export async function canEdit(tid: (number | string), uid: (number | string)) {
     return await isOwnerOrAdminOrMod(tid, uid);
 }
-exports.canEdit = canEdit;
+
+
+

--- a/src/types/topic.ts
+++ b/src/types/topic.ts
@@ -29,11 +29,11 @@ export type TopicObject = {
   title: string;
   slug: string;
   mainPid: number;
-  postcount: string;
+  postcount: string | number;
   viewcount: string;
   postercount: string;
   deleted: string;
-  deleterUid: string;
+  deleterUid: string | number;
   titleRaw: string;
   locked: string;
   pinned: number;


### PR DESCRIPTION
resolves #42 

Converted `src/privileges/topics.js` from TS to JS
- Added `src/privileges/topics.ts`
- Generated `src/privileges/topics.js` using `npx tsc`
- Added type annotations in compliance with the linter
- Still passes all tests when testing locally 
- Silenced `@typescript-eslint/no-unsafe-member-access` and `@typescript-eslint/no-unsafe-call errors` when calling a function on untranslated modules
